### PR TITLE
Fix crash from removed asyncio.coroutine() in search_packages

### DIFF
--- a/backend/services/package_service.py
+++ b/backend/services/package_service.py
@@ -78,17 +78,6 @@ async def search_packages(query: str, source: str = "all") -> list[dict]:
 
     results = []
 
-    if source in ("all", "pacman"):
-        pacman_task = pacman_service.search_packages(query)
-    else:
-        pacman_task = asyncio.coroutine(lambda: [])()
-
-    if source in ("all", "aur"):
-        aur_task = aur_service.search_packages(query)
-    else:
-        aur_task = asyncio.coroutine(lambda: [])()
-
-    # Run both searches concurrently
     if source == "all":
         pacman_results, aur_results = await asyncio.gather(
             pacman_service.search_packages(query),


### PR DESCRIPTION
asyncio.coroutine was removed in Python 3.11, so searching with source=pacman or source=aur raised AttributeError. The fallback tasks it built were also dead code, since the source=="all" branch already re-invoked the search calls directly instead of awaiting them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package searches now query only the selected source when searching Pacman or AUR.
  * “All” searches continue to query both sources concurrently and combine the results.
  * Reduced unnecessary background search activity for single-source queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->