### PR TITLE
ci: add SonarCloud PR analysis workflow with quality gate check

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,32 @@
+name: SonarCloud Code Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Quality Gate Check
+        uses: SonarSource/sonarqube-quality-gate-action@v1
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+# SonarCloud project configuration.
+# Replace sonar.organization / sonar.projectKey with the values shown on your
+# SonarCloud project's Administration > General Settings page after you
+# import this repo at https://sonarcloud.io/projects/create
+sonar.organization=CHANGE_ME_org-key
+sonar.projectKey=CHANGE_ME_0x5t4l1n_AURHub
+
+sonar.sources=backend,frontend/src
+sonar.exclusions=frontend/.vite/**,frontend/dist/**,**/__pycache__/**
+
+sonar.python.version=3.12


### PR DESCRIPTION
Runs SonarCloud scan on every push to main and every PR, then fails the job if the quality gate doesn't pass. Combined with a required status check in branch protection, this blocks merging PRs that fail the gate.

Requires manual one-time setup (see PR description): import the repo into SonarCloud, add SONAR_TOKEN as a repo secret, fill in the organization/projectKey placeholders in sonar-project.properties, and mark the "SonarCloud" job as a required status check on main.