### PR TITLE
docs: trim trailing whitespace in footer line

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,5 +102,5 @@ GNU GPL v3.0 or later — see [LICENSE](../LICENSE) for full terms.
 ---
 
 <div align="center">
-Built for Arch Linux 
+Built for Arch Linux
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed trailing whitespace from the documentation formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->