### PR TITLE
test: verify SonarCloud secret-scanning detects leaked credentials

### DIFF
--- a/backend/scanner/_sonarqube_secrets_check.py
+++ b/backend/scanner/_sonarqube_secrets_check.py
@@ -1,0 +1,19 @@
+"""
+TEMPORARY FILE - DO NOT MERGE.
+
+Secret-scanning verification (SonarCloud "Secrets" engine, not language-
+specific taint analysis). Uses the industry-standard dummy test strings
+that AWS's own docs and every secret-scanner (TruffleHog, Gitleaks,
+GitHub secret scanning, SonarCloud) use as canonical examples - these are
+publicly documented placeholders, not real credentials.
+
+Rule family : secrets:S6290 (AWS credentials), secrets:S6334 (generic
+              high-entropy / provider tokens)
+
+Not imported anywhere - exists only to confirm the SonarCloud PR check
+flags leaked secrets. Delete this file once confirmed.
+"""
+
+AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+GITHUB_TOKEN = "ghp_16C7e42F292c6912E7710c838347Ae178B4a"


### PR DESCRIPTION
Uses AWS's and GitHub's own publicly-documented dummy example tokens (industry-standard test vectors, not real secrets) to check the pattern-based Secrets engine independent of any Python-specific taint/sink model. Not imported anywhere. DO NOT MERGE - delete once confirmed.